### PR TITLE
Configure log rotation for frigate.log

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -11,8 +11,14 @@
         <application>frigate</application>
     </define>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${appDir}/frigate.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${appDir}/frigate.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
         <encoder>
             <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
## Size-based rotation:
- When frigate.log reaches 100MB, it rotates immediately

## Time-based rotation:
- Daily at midnight (default logback behavior)

## How it works:
1. **During operation**: If the file hits 100MB, it gets rotated right away to `frigate.YYYY-MM-DD.0.log.gz`
2. **Daily**: Even if the file is smaller than 100MB, it rotates at midnight to `frigate.YYYY-MM-DD.0.log.gz`
3. **Multiple rotations per day**: If the file hits 100MB multiple times in one day, you get `frigate.YYYY-MM-DD.0.log.gz`, `frigate.YYYY-MM-DD.1.log.gz`, etc.

## Cleanup:
- Keeps 30 days of rotated logs
- Maximum 3GB total log storage
- Old files are automatically deleted